### PR TITLE
Fargate 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Creates a CodePipeline specifically for a fargate project. The pipeline it creat
 ## Usage
 ```hcl
 module "codepipeline" {
-  source = "git@github.com:byu-oit/terraform-aws-fargate-codepipeline?ref=v0.0.8"
+  source = "git@github.com:byu-oit/terraform-aws-fargate-codepipeline?ref=v0.1.0"
   pipeline_name = "example"
   role_permissions_boundary_arn = module.acs.role_permissions_boundary.arn
   power_builder_role_arn        = module.acs.power_builder_role.arn

--- a/terraform-buildspec-helper/main.tf
+++ b/terraform-buildspec-helper/main.tf
@@ -1,8 +1,7 @@
 locals {
   install_terraform = [
     "wget ${var.terraform_url}${var.terraform_archive_name}",
-    "unzip ${var.terraform_archive_name}",
-    "mv terraform /bin"
+    "unzip ${var.terraform_archive_name} -d /bin"
   ]
 
   run_terraform = [
@@ -14,10 +13,7 @@ locals {
   ]
 
   extract_appspec = [
-    "cd $TERRAFORM_APPLICATION_DIR",
-    "terraform output appspec > appspec.json 2>/dev/null",
-    "mv appspec.json $CODEBUILD_SRC_DIR/.",
-    "cd $CODEBUILD_SRC_DIR"
+    "mv $TERRAFORM_APPLICATION_DIR/appspec.json $CODEBUILD_SRC_DIR/."
   ]
 
   appspec_artifacts = [

--- a/variables.tf
+++ b/variables.tf
@@ -75,12 +75,12 @@ variable "tags" {
 variable "terraform_url" {
   type = string
   description = "URL to download terraform executable from"
-  default = "https://releases.hashicorp.com/terraform/0.12.20/"
+  default = "https://releases.hashicorp.com/terraform/0.12.23/"
 }
 
 variable "terraform_archive_name" {
   type = string
   description = "Zipfile archive name to download Terraform"
-  default = "terraform_0.12.20_linux_amd64.zip"
+  default = "terraform_0.12.23_linux_amd64.zip"
 }
 


### PR DESCRIPTION
Updated to use appspec file as output by the fargate module 2.0.0. Also updated `unzip` to not potentially conflict with terraform directory name.